### PR TITLE
Adding a small wait after clicking the quick capture save button

### DIFF
--- a/RoamPrivateApi.js
+++ b/RoamPrivateApi.js
@@ -99,6 +99,7 @@ class RoamPrivateApi {
 			await page.type( '#block-input-quick-capture-window-qcapture', t );
 			await page.click( 'button.bp3-intent-primary' );
 		} );
+		await page.waitFor( 500 );
 		// page.close();
 		await this.close();
 		return;


### PR DESCRIPTION
As I was playing with this code this afternoon, I was seeing unreliable quick capture results. Sometimes data was being persisted, but the majority of the time it was not.

After poking around at things in the non-headless mode, I was able to determine that the window was being closed before the data was being persisted to the quick capture API.

Adding a 500ms wait after clicking the button seems to greatly improve reliability for me.