### PR TITLE
Support downloading MD and EDN exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ As mentioned, this is also a library that you can use within your project. Here 
 - [Sync your Roam graph to Evernote](https://github.com/artpi/roam-research-private-api/blob/master/examples/sync_evernote.js)
 - [Import arbitrary data into any note](https://github.com/artpi/roam-research-private-api/blob/master/examples/import-data.js)
 - [Send note to Roam using the Quick Capture feature](https://github.com/artpi/roam-research-private-api/blob/master/examples/quick_capture.js)
+- [Download an EDN backup](https://github.com/artpi/roam-research-private-api/blob/master/examples/download-edn.js)
 
 ###
 

--- a/examples/cmd.js
+++ b/examples/cmd.js
@@ -121,16 +121,23 @@ const argv = yargs
 		}
 	)
 	.command(
-		'export <dir> [exporturl]',
+		'export [--format json|md|edn] <dir> [exporturl]',
 		'Export your Roam database to a selected directory. If URL is provided, then the concent will be sent by POST request to the specified URL.',
-		() => {},
+                ( yargs ) => {
+                  yargs.option('format', {
+                    type: 'string',
+                    choices: ['json', 'md', 'edn'],
+                    desc: 'The format of the graph export to download',
+                    default: 'json',
+                  })
+                },
 		( argv ) => {
 			const RoamPrivateApi = require( '../' );
 			const api = new RoamPrivateApi( argv.graph, argv.email, argv.password, {
 				headless: ! argv.debug,
 				folder: argv['dir']
 			} );
-			let promises = api.getExportData( argv['removezip'] );
+			let promises = api.getExportData( argv['removezip'], argv.format );
 			promises.then( data => console.log( 'Downloaded' ) );
 			if ( argv['exporturl'] ) {
 				promises.then( data => fetch( argv['exporturl'], {

--- a/examples/download-edn.js
+++ b/examples/download-edn.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const RoamPrivateApi = require( '../' );
+const secrets = require( '../secrets.json' );
+
+async function run() {
+	const api = new RoamPrivateApi( secrets.graph, secrets.email, secrets.password, {
+		headless: false,
+		folder: '.',
+		nodownload: false,
+	} );
+
+	let filename = await api.getExportZip( 'edn' );
+
+	console.log( `Wrote to ${ filename }` );
+}
+
+run().catch( ( e ) => {
+	console.error( e );
+	process.exit( 1 );
+} );


### PR DESCRIPTION
This adds an extra parameter to the `getExportData` function to allow download any of the three supported export formats. I also added a `getExportZip` function which is basically the same thing but just returns the path to the downloaded ZIP file, which can be more convenient for non-JSON formats.